### PR TITLE
Fix for "float"

### DIFF
--- a/getComputedStyle.js
+++ b/getComputedStyle.js
@@ -38,6 +38,8 @@
 		for (property in currentStyle) {
 			if (/width|height|margin.|padding.|border.+W/.test(property) && style[property] !== 'auto') {
 				style[property] = getPixelSize(element, currentStyle, property, fontSize) + 'px';
+			} else if (property === 'styleFloat') {
+				style['float'] = currentStyle[property];
 			} else {
 				style[property] = currentStyle[property];
 			}


### PR DESCRIPTION
In oldIE's `currentStyle` object, the "float" property is called "styleFloat" (likely due to the word "float" previously being a reserved word in ECMAScript).
