### PR TITLE
Added polyfill for getPropertyValue

### DIFF
--- a/getComputedStyle.js
+++ b/getComputedStyle.js
@@ -55,7 +55,9 @@
 	CSSStyleDeclaration.prototype = {
 		constructor: CSSStyleDeclaration,
 		getPropertyPriority: function () {},
-		getPropertyValue: function () {},
+		getPropertyValue: function ( prop ) {
+			return this[prop] || '';
+		},
 		item: function () {},
 		removeProperty: function () {},
 		setProperty: function () {},


### PR DESCRIPTION
Hey,

I've added a simple polyfill for getPropertyValue method. 

It returns an empty string if no property is found as according to [here](http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-getPropertyValue)

Thanks,
Pat
