### PR TITLE
Ignore style properties that cannot be accessed

### DIFF
--- a/getComputedStyle.js
+++ b/getComputedStyle.js
@@ -39,7 +39,11 @@
 			} else if (property === 'styleFloat') {
 				style['float'] = currentStyle[property];
 			} else {
-				style[property] = currentStyle[property];
+				try {
+					style[property] = currentStyle[property];
+				} catch(e) {
+					// Do nothing
+				}
 			}
 		}
 


### PR DESCRIPTION
A style property that is defined and enumerable, but not valid, will cause exceptions at runtime.
